### PR TITLE
#10 テストコードの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,14 @@
   },
   "engines": {
     "node": "v8.9.4"
+  },
+  "devDependencies": {
+    "mocha": "^5.2.0",
+    "chai": "^4.1.2",
+    "coffee-script": "^1.12.7",
+    "hubot-test-helper": "^1.9.0"
+  },
+  "scripts": {
+    "test": "mocha --compilers coffee:coffee-script/register test"
   }
 }

--- a/test/cat.coffee
+++ b/test/cat.coffee
@@ -16,7 +16,7 @@ describe 'cat', ->
 
     it 'should reply to user', ->
       expect(this.room.messages).to.eql [
-        ['uncle','@hubot �~A��~A~S�~A��~B~C�~B~S'],
+        ['uncle','@hubot ねこちゃん'],
         ['hubot','http://livedoor.blogimg.jp/miniminigob/imgs/d/c/dc889573.jpg'],
       ]
 

--- a/test/cat.coffee
+++ b/test/cat.coffee
@@ -1,0 +1,22 @@
+Helper = require('hubot-test-helper');
+scriptHelper = new Helper('./../scripts/cat.coffee');
+co     = require('co');
+expect = require('chai').expect;
+
+describe 'cat', ->
+  beforeEach ->
+    this.room = scriptHelper.createRoom()
+
+  afterEach ->
+    this.room.destroy()
+
+  context 'user says cats to hubot', ->
+    beforeEach ->
+      this.room.user.say 'uncle', '@hubot �~A��~A~S�~A��~B~C�~B~S'
+
+    it 'should reply to user', ->
+      expect(this.room.messages).to.eql [
+        ['uncle','@hubot �~A��~A~S�~A��~B~C�~B~S'],
+        ['hubot','http://livedoor.blogimg.jp/miniminigob/imgs/d/c/dc889573.jpg'],
+      ]
+

--- a/test/cat.coffee
+++ b/test/cat.coffee
@@ -12,7 +12,7 @@ describe 'cat', ->
 
   context 'user says cats to hubot', ->
     beforeEach ->
-      this.room.user.say 'uncle', '@hubot �~A��~A~S�~A��~B~C�~B~S'
+      this.room.user.say 'uncle', '@hubot ねこちゃん'
 
     it 'should reply to user', ->
       expect(this.room.messages).to.eql [


### PR DESCRIPTION
#10 の対応でテストコードを追加

一旦、ci等の設定はなくテストを実行できる環境を整えたので次のPRでCI対応をする
本PRではテスト実行までがスコープ

使用したテストフレームワークは[hubot-test-helper](https://www.npmjs.com/package/hubot-test-helper)

今後のリリース予定では
- 本PRのリリース
- @rosso357 にも手伝ってもらいつつ既存のテストコードを作成
- ciで自動テストができる様に設定を変更する
- githubのmerge条件にテストが通っていることを追加
